### PR TITLE
Removed extra / in glossary related link

### DIFF
--- a/overview/index.md
+++ b/overview/index.md
@@ -328,7 +328,7 @@ The following table lists the supported national languages and language codes fo
 * [{{site.data.keyword.Bluemix_notm}} Prerequisites](https://developer.ibm.com/bluemix/support/#prereqs)
 * [What's new in {{site.data.keyword.Bluemix_notm}}](../whatsnew/index.html)
 * [{{site.data.keyword.Bluemix_notm}} known issues](https://developer.ibm.com/bluemix/support/#issues)
-* [{{site.data.keyword.Bluemix_notm}} glossary](/glossary/index.html)
+* [{{site.data.keyword.Bluemix_notm}} glossary](glossary/index.html)
 * [{{site.data.keyword.Bluemix_notm}} Pricing Sheet](https://console.{{site.data.keyword.domainname}}/pricing/)
 * [{{site.data.keyword.Bluemix_notm}} DevOps Services](https://hub.jazz.net)
 * [Cloud Foundry](http://cloudfoundry.org/)


### PR DESCRIPTION
Hi @jbetht  that / in front of (/glossary/index.html) was causing the url to render as https://www.ng.bluemix.net/docs/overview//glossary/index.html - it still works but lets remove it just to be safe. Please approve this change :|