### PR TITLE
link from Cordova docs to iOS doc didn't work

### DIFF
--- a/services/mobileaccess/google-auth-cordova.md
+++ b/services/mobileaccess/google-auth-cordova.md
@@ -8,7 +8,7 @@ In order to configure Cordova applications for Google authentication integration
 * Manually protect your backend application with {{site.data.keyword.amashort}} Server SDK. For more information, see [Protecting resources](protecting-resources.html).
 * (optional) Get familiar with the following sections:
    * [Enabling Google authentication in Android apps](google-auth-android.html)
-   * [Enabling Google authentication in iOS apps](google-auth-iOS.html)
+   * [Enabling Google authentication in iOS apps](google-auth-ios.html)
 
 
 ## Configuring the Android Platform


### PR DESCRIPTION
I'm not sure the reason, but I'm guessing it is a case issue on the link.  But if you try to go to the Google authentication iOS help from the Cordova help, you get a Page Not Found error.