### PR TITLE
OpenWhisk Reference typos

### DIFF
--- a/openwhisk/openwhisk_reference.md
+++ b/openwhisk/openwhisk_reference.md
@@ -314,7 +314,7 @@ You can also include any compilation steps or dependencies by modifying the `doc
 | hourRate | a user cannot invoke more than this many actions per hour | per user | number | 3600 |
 
 ### Per action timeout (ms) (Default: 60s)
-* The timeout limit N is in the range [100ms..300000ms] and is set per action in millioseconds.
+* The timeout limit N is in the range [100ms..300000ms] and is set per action in milliseconds.
 * A user can change the limit when creating the action.
 * A container that runs longer than N milliseconds is terminated.
 

--- a/openwhisk/openwhisk_reference.md
+++ b/openwhisk/openwhisk_reference.md
@@ -122,7 +122,7 @@ An activation record contains the following fields:
 ## JavaScript actions
 {: #openwhisk_ref_javascript}
 
-### Function protoype
+### Function prototype
 
 {{site.data.keyword.openwhisk_short}} JavaScript actions run in a Node.js runtime, currently version 0.12.9.
 


### PR DESCRIPTION
Hello there!

I found and fixed a couple of typos in OpenWhisk Reference (available here: https://new-console.ng.bluemix.net/docs/openwhisk/openwhisk_reference.html).