### PR TITLE
Fixing broken links

### DIFF
--- a/cli/index.md
+++ b/cli/index.md
@@ -18,12 +18,12 @@ Download and install command line interfaces to support your {{site.data.keyword
 
 | *{{site.data.keyword.Bluemix_notm}}: bx* | *Cloud Foundry: cf* |
 |---------------------|---------------|
-| [Download CLI](http://clis.{DomainName}/) <br> [View Docs](./reference/bluemix_cli/index.html)|  [Download CLI](https://github.com/cloudfoundry/cli/releases){: new_window}  <br> [View Docs](./reference/cfcommands/index.html) |
+| [Download CLI](http://clis.ng.bluemix.net/) <br> [View Docs](./reference/bluemix_cli/index.html)|  [Download CLI](https://github.com/cloudfoundry/cli/releases){: new_window}  <br> [View Docs](./reference/cfcommands/index.html) |
 
 
 ## ![Command line interface plug-ins](./images/CLI_Plugin.svg) Command line interface plug-ins
 
-Easily extend your {{site.data.keyword.Bluemix_notm}} command line interface with more commands. To access the {{site.data.keyword.Bluemix_notm}} command line interface plug-ins, see the [CLI Plug-in Repository](http://plugins.{DomainName}/).
+Easily extend your {{site.data.keyword.Bluemix_notm}} command line interface with more commands. To access the {{site.data.keyword.Bluemix_notm}} command line interface plug-ins, see the [CLI Plug-in Repository](http://plugins.ng.bluemix.net/).
 
 ### Extend your {{site.data.keyword.Bluemix_notm}} command line interface: bx
 


### PR DESCRIPTION
Links to Bluemix CLI and CLI Plug-in Repository is broken when domain is not ng.bluemix.net
Modified these links to absolute links to ng.bluemix.net