### PR TITLE
typo use iOS instead of ios

### DIFF
--- a/openwhisk/openwhisk_mobile_sdk.md
+++ b/openwhisk/openwhisk_mobile_sdk.md
@@ -61,7 +61,7 @@ You can use the {{site.data.keyword.openwhisk_short}} CLI to download example co
 
 To install the starter app example, enter the following command:
 ```
-wsk sdk install ios
+wsk sdk install iOS
 ```
 {: pre}
 


### PR DESCRIPTION
typo use iOS instead of ios for the command wsk sdk install iOS
$ wsk sdk install ios
Unknown SDK component: ios

$ wsk sdk install iOS

Downloaded OpenWhisk iOS starter app. Unzip OpenWhiskIOSStarterApp.zip and open the project in Xcode.