### PR TITLE
Update customizingJRE.md

### DIFF
--- a/runtimes/liberty/customizingJRE.md
+++ b/runtimes/liberty/customizingJRE.md
@@ -271,7 +271,7 @@ For example, if you want to use AES 256-bit encryption, you need to overlay thes
 
 Download the appropriate unrestricted policy files and add them to your application as:
 ```
-    resources\.java-overlay\.java\lib\security\US_export_policy.jar
+    resources\.java-overlay\.java\jre\lib\security\US_export_policy.jar
     resources\.java-overlay\.java\jre\lib\security\local_policy.jar
 ```
 {: #codeblock}


### PR DESCRIPTION
Fixing path in last code block. The 2nd last code block incidentally has it right. It is important because if you put that one file in the wrong spot, the JCEs wont be accepted