### PR TITLE
Update index.md

### DIFF
--- a/services/probabilisticmatch/index.md
+++ b/services/probabilisticmatch/index.md
@@ -182,9 +182,9 @@ searchPerson: POST    https://pme.mybluemix.net/mdmcloud/pme/search/person
 >
 ># Related Links {:class="linklist"}
 >## COMPATIBLE RUNTIMES {:id="buildpacks"}
->* [Liberty for Java](../../starters/liberty/index.html#liberty)
->* [SDK for Node.js](../../starters/nodejs/index.html#nodejs)
->* [Ruby on Rails](../../starters/rails/index.html#rails)
+>* [Liberty for Java](../../runtimes/liberty/index.html#liberty)
+>* [SDK for Node.js](../../runtimes/nodejs/index.html#nodejs)
+>* [Ruby on Rails](../../runtimes/ruby/index.html#rails)
 >
 ># Related Links {:class="linklist"}
 >## RELATED LINKS {:id="general"}


### PR DESCRIPTION
changes in links from 'starters' path to the new path 'runtimes' and change in path from old 'rails' to current name 'ruby'