### PR TITLE
Use same region name as in Bluemix UI

### DIFF
--- a/toolchains/toolchains_overview.md
+++ b/toolchains/toolchains_overview.md
@@ -18,7 +18,7 @@ A *toolchain* is a set of tools that work together to support development, deplo
 
 You can use one of the provided toolchain templates as a starting point to create a toolchain with a specific set of integrated tools or you can create an empty toolchain and add only the tools that you want.  
 
-**Important**: This capability is experimental. Toolchains might not be stable and might change in ways that are not compatible with earlier versions. They are not recommended for use in production environments. To use toolchains, you must make a one-time [request for access](https://new-console.ng.bluemix.net/devops?cm_mmc=IBMBluemixGarageMethod-_-MethodSite-_-10-19-15::12-31-18-_-toolchains-welcome-page){: new_window}.  Toolchains are available in the Dallas region only.  
+**Important**: This capability is experimental. Toolchains might not be stable and might change in ways that are not compatible with earlier versions. They are not recommended for use in production environments. To use toolchains, you must make a one-time [request for access](https://new-console.ng.bluemix.net/devops?cm_mmc=IBMBluemixGarageMethod-_-MethodSite-_-10-19-15::12-31-18-_-toolchains-welcome-page){: new_window}.  Toolchains are available in the US South region only.  
 
 
 # Related Links


### PR DESCRIPTION
In the UI, the region seems to always be called 'US South' rather than the more specific region of 'Dallas' (even though US-South is in reality in the Softlayer data centers in Dallas, I think the use of 'US South' would be more consistent)