### PR TITLE
Update sharetextpipelines.md

### DIFF
--- a/develop/nl/ja/sharetextpipelines.md
+++ b/develop/nl/ja/sharetextpipelines.md
@@ -83,7 +83,8 @@ stages:
 ```
 {: codeblock} 
 
-##YAML ファイルの構文{: #yaml-syntax}
+##YAML ファイルの構文
+{: #yaml-syntax}
 
 どのようなパイプラインも、以下の構文を使用してテキストで表現することができます。
 


### PR DESCRIPTION
achor tags shows in sub-title and separate line after the translation.