### PR TITLE
Update with correct order of CLI installation

### DIFF
--- a/starters/install_cli.md
+++ b/starters/install_cli.md
@@ -33,10 +33,10 @@ copyright:
 You can use the command line interface to deploy and modify applications and service instances.
 {:shortdesc}
 
-Before you begin, install the {{site.data.keyword.Bluemix}} and Cloud Foundry command line interfaces.
+Before you begin, install the Cloud Foundry and {{site.data.keyword.Bluemix}} command line interfaces.
 
 <p>
-<a class="xref" href="http://clis.ng.bluemix.net/ui/home.html" target="_blank" title="(Opens in a new tab or window)"><img class="image" src="images/btn_bx_commandline.svg" alt="Download {{site.data.keyword.Bluemix}} command line interface" /> </a>  <a class="xref" href="https://github.com/cloudfoundry/cli/releases" target="_blank" title="(Opens in a new tab or window)"><img class="image" src="images/btn_cf_commandline.svg" alt="Download Cloud Foundry command line interface" /> </a> 
+<a class="xref" href="https://github.com/cloudfoundry/cli/releases" target="_blank" title="(Opens in a new tab or window)"><img class="image" src="images/btn_cf_commandline.svg" alt="Download Cloud Foundry command line interface" /> </a>  <a class="xref" href="http://clis.ng.bluemix.net/ui/home.html" target="_blank" title="(Opens in a new tab or window)"><img class="image" src="images/btn_bx_commandline.svg" alt="Download {{site.data.keyword.Bluemix}} command line interface" /> </a>
 </p>
 
 **Restriction:** The command line tools are not supported by Cygwin. Use the tools in a command line window other than the Cygwin command line window.


### PR DESCRIPTION
Existing page continually states "Install the Bluemix CLI and the Cloud Foundry CLI"; but the Bluemix CLI is dependent on the CF CLI; it can't be installed without that dependency. We should put the links in the order in which people need to install.