### PR TITLE
Fix Rails documentation link

### DIFF
--- a/runtimes/ruby/index.md
+++ b/runtimes/ruby/index.md
@@ -64,4 +64,4 @@ deploy the app.
 # rellinks
 ## general
 * [Cloud Foundry buildpack for Ruby](https://github.com/cloudfoundry/cf-buildpack-ruby)
-* [Ruby on Rails documentation](http://rubyonrails.org/documentation/)
+* [Ruby on Rails documentation](http://api.rubyonrails.org/)


### PR DESCRIPTION
Problem:
Link to Ruby on Rails Documentation broken

Solution:
Link should point to either the API docs or the guides.
The API docs link has been chosen here since the guides are more of learning resources than simple documentation.