### PR TITLE
Fix Bluemix CLI Plugin Repository URLs

### DIFF
--- a/cli/cliplug-in.md
+++ b/cli/cliplug-in.md
@@ -20,6 +20,6 @@ copyright:
 *Last updated: 2 Feburary 2016*
 {: .last-updated}
 
-You can install and use Cloud Foundry Command Line Interface (cf cli) plug-ins that are available on [CLI Plug-in Repository](http://plugins.{DomainName}/){: new_window}. Each plug-in is identified by its binary file name, its developer-defined plug-in name, and the commands that the plug-in provides. You can use the binary file name only to install a plug-in, and use the plug-in name or a command for any other action.
+You can install and use Cloud Foundry Command Line Interface (cf cli) plug-ins that are available on [CLI Plug-in Repository](http://plugins.ng.bluemix.net/){: new_window}. Each plug-in is identified by its binary file name, its developer-defined plug-in name, and the commands that the plug-in provides. You can use the binary file name only to install a plug-in, and use the plug-in name or a command for any other action.
 {:shortdesc}
 

--- a/cli/plugins/auto-scaling/index.md
+++ b/cli/plugins/auto-scaling/index.md
@@ -23,7 +23,7 @@ copyright:
 You can configure the {{site.data.keyword.autoscaling}} service by using the {{site.data.keyword.autoscaling}} CLI for {{site.data.keyword.Bluemix_notm}}. The {{site.data.keyword.autoscaling}} CLI supports Linux64, Win64, and OSX, and provides functionality that is similar to the auto-scaling RESTful API provides.
 {: shortdesc}
 
-Before you begin, install the {{site.data.keyword.Bluemix_notm}} CLI. See [Download {{site.data.keyword.Bluemix_notm}} CLI](http://plugins.{DomainName}/ui/home.html){: new_window} for instructions.
+Before you begin, install the {{site.data.keyword.Bluemix_notm}} CLI. See [Download {{site.data.keyword.Bluemix_notm}} CLI](http://plugins.ng.bluemix.net/ui/home.html){: new_window} for instructions.
 
 ## Adding the {{site.data.keyword.Bluemix_notm}} CLI plug-in
 
@@ -126,7 +126,7 @@ You can show the history of the auto-scaling activity of a specific app. A table
 ## general
 {: #general}
 * [{{site.data.keyword.autoscaling}} service](../../../services/Auto-Scaling/index.html)
-* [{{site.data.keyword.Bluemix_notm}} CLI](http://plugins.{DomainName}/ui/home.html){: new_window}
+* [{{site.data.keyword.Bluemix_notm}} CLI](http://plugins.ng.bluemix.net/ui/home.html){: new_window}
 * [W3C Date and Time Formats standard](https://www.w3.org/TR/NOTE-datetime){: new_window}
 
 

--- a/cli/plugins/dev_mode/index.md
+++ b/cli/plugins/dev_mode/index.md
@@ -37,7 +37,7 @@ You can do the following tasks with the dev_mode CLI:
 
 Use one of the following methods to install the dev_mode command line tool:
 - Install locally.
-  1. Download the dev_mode plug-in for your platform from [IBM Bluemix CLI Plugin Repository](http://plugins.{DomainName}).
+  1. Download the dev_mode plug-in for your platform from [IBM Bluemix CLI Plugin Repository](http://plugins.ng.bluemix.net).
   2. Go to the folder that the dev_mode plug-in is saved, and install the dev_mode plug-in by using the cf install-plugin command. For example: 
   
         ```


### PR DESCRIPTION
There isn't a domain-specific version of the CLI plugins repository, it is only available at plugins.ng.bluemix.net as per discussion on [slack](https://ibm-cloudplatform.slack.com/archives/feedback/p1469012465000068)

So (e.g.,) https://new-console.eu-gb.bluemix.net/docs/cli/cliplug-in.html contains a 404 link.