### PR TITLE
Fixed link to missing content

### DIFF
--- a/services/IoT/reference/mqtt/index.md
+++ b/services/IoT/reference/mqtt/index.md
@@ -14,7 +14,7 @@ copyright:
 
 # MQTT messaging
 {: #ref-mqtt}
-Last updated: 6 September 2016
+Last updated: 13 September 2016
 {: .last-updated}
 
 MQTT is the primary protocol that devices and applications use to communicate with the {{site.data.keyword.iot_full}}. MQTT is a publish and subscribe messaging transport protocol that is designed for the efficient exchange of real-time data between sensor and mobile devices.
@@ -38,8 +38,6 @@ MQTT version | Deviations | Notes
 {{site.data.keyword.iot_short_notm}} supports any content that is permitted by the MQTT standard. MQTT is data-agnostic so it's possible to send images, texts in any encoding, encrypted data, and virtually every type of data in binary format. For more information about the MQTT standard, see the following resources:
 - [MQTT.org](http://mqtt.org/)
 - [HiveMQ: Introducing MQTT](http://www.hivemq.com/blog/mqtt-essentials-part-1-introducing-mqtt)
-
-For information about message payload size limits and format restrictions for specific use cases for {{site.data.keyword.iot_short_notm}}, see [MQTT messaging](mqtt/index.html).
 
 ## Application, device, and gateway clients
 {: #device-app-clients}

--- a/services/IoT/reference/mqtt/index.md
+++ b/services/IoT/reference/mqtt/index.md
@@ -28,7 +28,18 @@ MQTT runs over TCP/IP, and while it is possible to code directly to TCP/IP, you 
 ## Version support
 {: #version-support}
 
-For information about the versions of MQTT that are supported by  {{site.data.keyword.iot_short_notm}}, see [Standards and requirements](../standards_and_requirements.html#mqtt).
+{{site.data.keyword.iot_short_notm}} supports the following versions of the MQTT messaging protocol:
+
+MQTT version | Deviations | Notes
+--- | --- | ---
+[3.1.1](https://www.oasis-open.org/standards#mqttv3.1.1) (recommended) | Retained messages are not supported, for example, shared subscriptions. | <ul><li>OASIS Standard.<li>ISO standard (ISO/IEC PRF 20922) <li>Improved interoperability between various clients and severs due to a more precise definition of the protocol compared to V3.1.   <li>The maximum length of the MQTT client identifier (ClientId) is increased to 256 from the 23 character limit that is imposed by V3.1. </br>The {{site.data.keyword.iot_short_notm}} service often requires longer client IDs (ClientId). </br>Long client IDs are supported regardless of the MQTT protocol version, however some V3.1 client libraries check the length of the ClientId value and enforce the 23 character limit.</ul>
+3.1 | - | MQTT V3.1 is the version of the protocol that is in widest use today.
+
+{{site.data.keyword.iot_short_notm}} supports any content that is permitted by the MQTT standard. MQTT is data-agnostic so it's possible to send images, texts in any encoding, encrypted data, and virtually every type of data in binary format. For more information about the MQTT standard, see the following resources:
+- [MQTT.org](http://mqtt.org/)
+- [HiveMQ: Introducing MQTT](http://www.hivemq.com/blog/mqtt-essentials-part-1-introducing-mqtt)
+
+For information about message payload size limits and format restrictions for specific use cases for {{site.data.keyword.iot_short_notm}}, see [MQTT messaging](mqtt/index.html).
 
 ## Application, device, and gateway clients
 {: #device-app-clients}


### PR DESCRIPTION
Fixed link to standards topic that is still draft. Replaced it with destination information until topic goes live.