### PR TITLE
Add note about only paid accounts can create orgs

### DIFF
--- a/admin/orgs_spaces.md
+++ b/admin/orgs_spaces.md
@@ -23,6 +23,8 @@ Last updated: 16 August 2016
 As an account owner, you can manage your organizations by going to the **{{site.data.keyword.avatar}}** icon ![Avatar icon](../icons/i-avatar-icon.svg) &gt; **Manage Organizations** page. Organization managers can also use the Manage Organizations page to manage any organizations where they are set as the manager.
 {:shortdesc}
 
+Note: Only account owners with Pay-As-You-Go accounts can create an organization.
+
 Management tasks include the following:
 
 * Creating an organization or space


### PR DESCRIPTION
There is a note about only paid accounts being able to add/create orgs on the "Creating orgs and spaces" page but not on the "Managing orgs" page. So, thought it would be useful to add this note since I was on the Managing orgs topic and was puzzled why I could not create a new org following those steps. 