### PR TITLE
Fix Install link for Eclipse Tools for Bluemix

### DIFF
--- a/starters/deploy_eclipsetools.md
+++ b/starters/deploy_eclipsetools.md
@@ -15,15 +15,15 @@ copyright:
 {:shortdesc: .shortdesc}
 
 # Developing with Eclipse Tools
-*Last updated: 11 November 2015*
+*Last updated: 4 November 2016*
 
 {{site.data.keyword.eclipsetoolsfull}} provides lightweight tools in Eclipse for rapid development and integration of applications with {{site.data.keyword.Bluemix}} or Cloud Foundry Clouds.
 {:shortdesc}
 
-  1. If you don't already have Eclipse, install Eclipse Luna for Java EE Developers (4.4.1).
-  2. Click and hold the following button to drag and drop it into the Eclipse toolbar, and then follow the prompts to install IBM Eclipse Tools for {{site.data.keyword.Bluemix_notm}}:
+  1. If you don't already have Eclipse, install Eclipse Neon for Java EE Developers (4.6.1).
+  2. Click and hold the following button to drag and drop it into the Eclipse toolbar, and then follow the prompts to install IBM Eclipse Tools for {{site.data.keyword.Bluemix_notm}}:  
   
-  ![Drag and drop into a running Eclipse Luna workspace to install IBM Eclipse Tools for {{site.data.keyword.Bluemix_notm}}](images/installbutton.png)
+  [![Drag and drop into a running Eclipse Luna workspace to install IBM Eclipse Tools for {{site.data.keyword.Bluemix_notm}}](images/installbutton.png)](http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=1774120)
 
   3. {: download} Download your starter code and import it into Eclipse by going to **File > Import Existing Projects into Workspace > Archive File**.
   


### PR DESCRIPTION
Link for Eclipse Tools for Bluemix should point to our Eclipse Marketplace entry, and likewise should be updated to Neon.