### PR TITLE
Removed credits section

### DIFF
--- a/admin/softlayerlink.md
+++ b/admin/softlayerlink.md
@@ -5,7 +5,7 @@
 copyright:
 
   years: 2016
-lastupdated: "2016-11-03"
+lastupdated: "2016-11-30"
  
 
 ---
@@ -65,13 +65,6 @@ You must be a Master User in the SoftLayer account to link accounts.
 After you have linked your accounts, the **Go to {{site.data.keyword.Bluemix_notm}}** link is available in the SoftLayer global header. Clicking this link takes you to the {{site.data.keyword.Bluemix_notm}} login page. In addition, the **SoftLayer** link is now available in the {{site.data.keyword.Bluemix_notm}} header. Clicking the link takes you to the home page of the {{site.data.keyword.slportal}} in a new window.
 
 {{site.data.keyword.Bluemix_notm}} infrastructure offerings are connected to a three-tiered network, segmenting public, private, and management traffic. Infrastructure offerings on a customer's {{site.data.keyword.Bluemix_notm}} account might transfer data between one another across the private network at no cost. Infrastructure offerings, such as bare metal servers, virtual servers, and cloud storage, connect to other applications and services in the {{site.data.keyword.Bluemix_notm}} catalog, such as Watson services, containers, or runtimes, across the public network. Data transfer between those two types of offerings is metered and charged at standard public network bandwidth rates.
-
-## Credits for {{site.data.keyword.Bluemix_notm}} usage when accounts are linked
-{: #slcredit}
-
-When you link your {{site.data.keyword.Bluemix_notm}} account from your SoftLayer account, you receive a $200.00 credit that you can use within {{site.data.keyword.Bluemix_notm}} only. The credit must be used within 30 days of linking the accounts.
-
-For information about how to view the credits and expiration date, see [Viewing credits](https://console.ng.bluemix.net/docs/pricing/index.html#credits).
 
 ## Inviting SoftLayer team members to {{site.data.keyword.Bluemix_notm}}
 {: #invite_users}


### PR DESCRIPTION
Removed the credits section about the $200 when linking Bluemix and SoftLayer accounts.