### PR TITLE
Removed Key Protect London from regions table

### DIFF
--- a/services/index.md
+++ b/services/index.md
@@ -95,7 +95,7 @@ Not all services are available for purchase in every {{site.data.keyword.Bluemix
 |{{site.data.keyword.iot_short}}		|Hosted in Dallas,US		|Hosted in London,UK		|Not available in region|
 |{{site.data.keyword.iotrtinsights_short}}		|Hosted in Dallas,US		|Hosted in London,UK		|Hosted in Sydney,AU|
 |IoT Workbench		|Hosted in Dallas,US		|Hosted in London,UK		|Hosted in Sydney,AU|
-|{{site.data.keyword.keymanagementserviceshort}}	|Hosted in Dallas,US		|Hosted in London,UK		|Not available in region|
+|{{site.data.keyword.keymanagementserviceshort}}	|Hosted in Dallas,US		|Not available in region		|Not available in region|
 |{{site.data.keyword.languagetranslationshort}}	|Hosted in Dallas,US		|Hosted in Dallas,US		|Hosted in Dallas,US |
 |{{site.data.keyword.pm_short}}   |Hosted in Dallas,US		|Hosted in London,UK		|Not available in region|
 |{{site.data.keyword.eventhubshort}}		|Hosted in Dallas,US		|Not available in region		|Not available in region|


### PR DESCRIPTION
Please merge and request prod build. Key Protect will be removed on Dec 23rd.

See https://www.ibm.com/blogs/bluemix/2016/11/action-required-temporary-removal-ibm-key-protect-london-region/