### PR TITLE
Removed Service Proxy entry

### DIFF
--- a/services/reqnsi.md
+++ b/services/reqnsi.md
@@ -121,7 +121,6 @@ Not all services are available in every {{site.data.keyword.Bluemix_notm}} regio
 |{{site.data.keyword.relationshipextractionshort}}	|Yes	|Yes		|Yes|
 |{{site.data.keyword.retrieveandrankshort}}	|Yes 		|Yes 		|Yes|
 |{{site.data.keyword.SecureGateway}}		|Yes		|Yes		|No|
-|{{site.data.keyword.servicediscoveryshort}}	|Yes		|No		|No|
 |{{site.data.keyword.sescashort}}		|Yes		|Yes		|Yes|
 |{{site.data.keyword.ssofull}}			|Yes		|No		|No|
 |{{site.data.keyword.speechtotextshort}}	|Yes 		|Yes	 	|Yes|


### PR DESCRIPTION
SD is deprecated and removed from catalog (4th Jan). Removed its entry in the services table.