### PR TITLE
Update swagger link to new http-messaging page

### DIFF
--- a/services/IoT/applications/api.md
+++ b/services/IoT/applications/api.md
@@ -38,7 +38,7 @@ The {{site.data.keyword.iot_short_notm}} HTTP REST API supports the following ca
 ## Accessing the HTTP REST API
 {: #api_link}
 
-To access the {{site.data.keyword.iot_short_notm}} HTTP REST API and obtain more information about how to build and customize your applications, go to  https://docs.internetofthings.ibmcloud.com/swagger/v0002.html.
+To access the {{site.data.keyword.iot_short_notm}} HTTP REST API and obtain more information about how to build and customize your applications, go to  https://docs.internetofthings.ibmcloud.com/swagger/http-messaging.html.
 
 The only version of the {{site.data.keyword.iot_short_notm}} HTTP REST API that is supported is version 2. Ensure that your {{site.data.keyword.iot_short_notm}} solutions are using version 2.
 


### PR DESCRIPTION
Http messaging APIs moved to separate swagger page. Updated link to direct to the new page.