### PR TITLE
Dynatrace agent name change

### DIFF
--- a/runtimes/liberty/dynatrace.md
+++ b/runtimes/liberty/dynatrace.md
@@ -75,11 +75,11 @@ The Dynatrace agent must be hosted on a web server, and the Liberty buildpack mu
 ### Configuring the Liberty app
 {: #configuring_liberty_app}
 
-The Liberty app you want to monitor must be configured to locate the server hosting the agent jar you previously set up. You can configure the app with the **JBP_CONFIG_DYNATRACEAGENT** environment variable. The **JBP_CONFIG_DYNATRACEAGENT** environment variable tells the buildpack where to download the Dynatrace agent from. To set the environment variable, complete these steps:
+The Liberty app you want to monitor must be configured to locate the server hosting the agent jar you previously set up. You can configure the app with the **JBP_CONFIG_DYNATRACEAPPMONAGENT** environment variable. The **JBP_CONFIG_DYNATRACEAPPMONAGENT** environment variable tells the buildpack where to download the Dynatrace agent from. To set the environment variable, complete these steps:
 
-1. Set the variable **JBP_CONFIG_DYNATRACEAGENT** so it has the value *"repository_root: URL_of_server_hosting_index.yml"*. For example, after pushing your application issue the following command:
+1. Set the variable **JBP_CONFIG_DYNATRACEAPPMONAGENT** so it has the value *"repository_root: URL_of_server_hosting_index.yml"*. For example, after pushing your application issue the following command:
   
-        $ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
+        $ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
         {: codeblock}
 
     In this example, *my-dynatrace-agent-host.mybluemix.net* is the URL of the `index.yml` file hosted by the server that you previously configured.

--- a/runtimes/liberty/environmentVariables.md
+++ b/runtimes/liberty/environmentVariables.md
@@ -43,7 +43,7 @@ Environment variables supported by Liberty for Java.
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>Configure the [Dynatrace agent location information](dynatrace.html#configuring_liberty_app)</td>
 </tr>
 

--- a/runtimes/liberty/nl/de/dynatrace.md
+++ b/runtimes/liberty/nl/de/dynatrace.md
@@ -90,12 +90,12 @@ Der Dynatrace-Agent muss als Host einen Web-Server haben und das Liberty-Buildpa
 ### Liberty-App konfigurieren
 {: #configuring_liberty_app}
 
-Die zu überwachende Liberty-App muss konfiguriert werden, sodass sie nach der Agenten-JAR-Datei sucht, die Sie zuvor eingerichtet haben. Sie können die App mit der Umgebungsvariablen **JBP_CONFIG_DYNATRACEAGENT** konfigurieren. Die Umgebungsvariable **JBP_CONFIG_DYNATRACEAGENT** weist das Buildpack an, von welcher Position der Dynatrace-Agent herunterzuladen ist. Führen Sie zum Festlegen der Umgebungsvariablen folgende Schritte aus:
+Die zu überwachende Liberty-App muss konfiguriert werden, sodass sie nach der Agenten-JAR-Datei sucht, die Sie zuvor eingerichtet haben. Sie können die App mit der Umgebungsvariablen **JBP_CONFIG_DYNATRACEAPPMONAGENT** konfigurieren. Die Umgebungsvariable **JBP_CONFIG_DYNATRACEAPPMONAGENT** weist das Buildpack an, von welcher Position der Dynatrace-Agent herunterzuladen ist. Führen Sie zum Festlegen der Umgebungsvariablen folgende Schritte aus:
 <ol>
-   <li> Legen Sie die Variable **JBP_CONFIG_DYNATRACEAGENT** fest, sodass sie folgenden Wert aufweist: *"repository_root: URL_of_server_hosting_index.yml"*. Setzen Sie beispielsweise folgenden Befehl ab, nachdem Sie für Ihre Anwendung eine Push-Operation durchgeführt haben:
+   <li> Legen Sie die Variable **JBP_CONFIG_DYNATRACEAPPMONAGENT** fest, sodass sie folgenden Wert aufweist: *"repository_root: URL_of_server_hosting_index.yml"*. Setzen Sie beispielsweise folgenden Befehl ab, nachdem Sie für Ihre Anwendung eine Push-Operation durchgeführt haben:
   
   <pre>   
-    $ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
+    $ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
   </pre>
   {: codeblock}
 

--- a/runtimes/liberty/nl/de/environmentVariables.md
+++ b/runtimes/liberty/nl/de/environmentVariables.md
@@ -43,7 +43,7 @@ Von Liberty for Java unterstützte Umgebungsvariablen
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>Zum Konfigurieren der [Informationen zur Position des Dynatrace-Agenten](dynatrace.html#configuring_liberty_app).</td>
 </tr>
 

--- a/runtimes/liberty/nl/es/dynatrace.md
+++ b/runtimes/liberty/nl/es/dynatrace.md
@@ -83,13 +83,13 @@ El agente de Dynatrace debe estar alojado en un servidor web, y el paquete de co
 ### Configuración de la app de Liberty
 {: #configuring_liberty_app}
 
-La app de Liberty que desea supervisar deben estar configurada para localizar el servidor en el que se encuentra el jar del agente que ha establecido previamente. Puede configurar la app con la variable de entorno de **JBP_CONFIG_DYNATRACEAGENT**. La variable de entorno de **JBP_CONFIG_DYNATRACEAGENT** indica al paquete de compilación desde dónde se debe descargar el agente de Dynatrace. Para establecer la variable de entorno, siga estos pasos:
+La app de Liberty que desea supervisar deben estar configurada para localizar el servidor en el que se encuentra el jar del agente que ha establecido previamente. Puede configurar la app con la variable de entorno de **JBP_CONFIG_DYNATRACEAPPMONAGENT**. La variable de entorno de **JBP_CONFIG_DYNATRACEAPPMONAGENT** indica al paquete de compilación desde dónde se debe descargar el agente de Dynatrace. Para establecer la variable de entorno, siga estos pasos:
 <ol>
-   <li> Establezca la variable **JBP_CONFIG_DYNATRACEAGENT** para que tenga el valor
+   <li> Establezca la variable **JBP_CONFIG_DYNATRACEAPPMONAGENT** para que tenga el valor
    *"repository_root: URL_of_server_hosting_index.yml"*. Por ejemplo, después de enviar la aplicación, emita el siguiente mandato:
   
   <pre>   
-    $ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
+    $ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
   </pre>
   {: codeblock}
 

--- a/runtimes/liberty/nl/es/environmentVariables.md
+++ b/runtimes/liberty/nl/es/environmentVariables.md
@@ -43,7 +43,7 @@ Variables de entorno admitidas por Liberty para Java.
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>Configurar la [información sobre ubicación del agente de Dynatrace](dynatrace.html#configuring_liberty_app)</td>
 </tr>
 

--- a/runtimes/liberty/nl/fr/dynatrace.md
+++ b/runtimes/liberty/nl/fr/dynatrace.md
@@ -83,12 +83,12 @@ L'agent Dynatrace doit être hébergé sur un serveur Web, et le pack de constru
 ### Configuration de l'appli Liberty
 {: #configuring_liberty_app}
 
-L'appli Liberty que vous souhaitez surveiller doit être configurée pour localiser le serveur qui héberge le fichier JAR d'agent que vous avez précédemment configuré. Vous pouvez configurer l'appli avec la variable d'environnement **JBP_CONFIG_DYNATRACEAGENT**. La variable d'environnement **JBP_CONFIG_DYNATRACEAGENT** indique au pack de construction l'emplacement à partir duquel il doit télécharger l'agent Dynatrace. Pour définir la variable d'environnement, procédez comme suit :
+L'appli Liberty que vous souhaitez surveiller doit être configurée pour localiser le serveur qui héberge le fichier JAR d'agent que vous avez précédemment configuré. Vous pouvez configurer l'appli avec la variable d'environnement **JBP_CONFIG_DYNATRACEAPPMONAGENT**. La variable d'environnement **JBP_CONFIG_DYNATRACEAPPMONAGENT** indique au pack de construction l'emplacement à partir duquel il doit télécharger l'agent Dynatrace. Pour définir la variable d'environnement, procédez comme suit :
 <ol>
-   <li> Affectez à la variable **JBP_CONFIG_DYNATRACEAGENT** la valeur *"repository_root: URL_of_server_hosting_index.yml"*. Par exemple, après avoir envoyé par commande push votre application, exécutez la commande suivante :
+   <li> Affectez à la variable **JBP_CONFIG_DYNATRACEAPPMONAGENT** la valeur *"repository_root: URL_of_server_hosting_index.yml"*. Par exemple, après avoir envoyé par commande push votre application, exécutez la commande suivante :
   
   <pre>   
-    $ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
+    $ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
   </pre>
   {: codeblock}
 

--- a/runtimes/liberty/nl/fr/environmentVariables.md
+++ b/runtimes/liberty/nl/fr/environmentVariables.md
@@ -43,7 +43,7 @@ Variables d'environnement prises en charge par Liberty for Java.
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>Configurer les [informations d'emplacement d'agent Dynatrace](dynatrace.html#configuring_liberty_app)</td>
 </tr>
 

--- a/runtimes/liberty/nl/it/dynatrace.md
+++ b/runtimes/liberty/nl/it/dynatrace.md
@@ -89,13 +89,13 @@ L'agent Dynatrace deve essere ospitato su un server Web e il pacchetto di build 
 ### Configurazione dell'applicazione Liberty
 {: #configuring_liberty_app}
 
-L'applicazione Liberty che desideri monitorare deve essere configurata per individuare il server che ospita il jar dell'agent che hai precedentemente configurato. Puoi configurare l'applicazione con la variabile di ambiente **JBP_CONFIG_DYNATRACEAGENT**. La variabile di ambiente **JBP_CONFIG_DYNATRACEAGENT** indica che il pacchetto di build da cui scaricare l'agent Dynatrace. Per impostare la variabile di ambiente, completa la seguente procedura:
+L'applicazione Liberty che desideri monitorare deve essere configurata per individuare il server che ospita il jar dell'agent che hai precedentemente configurato. Puoi configurare l'applicazione con la variabile di ambiente **JBP_CONFIG_DYNATRACEAPPMONAGENT**. La variabile di ambiente **JBP_CONFIG_DYNATRACEAPPMONAGENT** indica che il pacchetto di build da cui scaricare l'agent Dynatrace. Per impostare la variabile di ambiente, completa la seguente procedura:
 <ol>
-   <li> Imposta la variabile **JBP_CONFIG_DYNATRACEAGENT** in modo che abbia il valore
+   <li> Imposta la variabile **JBP_CONFIG_DYNATRACEAPPMONAGENT** in modo che abbia il valore
    *"repository_root: URL_of_server_hosting_index.yml"*. Ad esempio, dopo aver eseguito il push della tua applicazione immetti il seguente comando:
   
   <pre>   
-    $ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
+    $ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
   </pre>
   {: codeblock}
 

--- a/runtimes/liberty/nl/it/environmentVariables.md
+++ b/runtimes/liberty/nl/it/environmentVariables.md
@@ -43,7 +43,7 @@ Variabili di ambiente supportate da Liberty for Java.
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>Configura le [informazioni di ubicazione dell'agent Dynatrace](dynatrace.html#configuring_liberty_app)</td>
 </tr>
 

--- a/runtimes/liberty/nl/ja/dynatrace.md
+++ b/runtimes/liberty/nl/ja/dynatrace.md
@@ -80,12 +80,12 @@ Dynatrace エージェントは Web サーバー上でホストされる必要�
 ### Liberty アプリケーションの構成
 {: #configuring_liberty_app}
 
-モニター対象の Liberty アプリケーションは、以前にセットアップしたエージェント jar をホストするサーバーを検出するように構成する必要があります。**JBP_CONFIG_DYNATRACEAGENT** 環境変数を使用してアプリケーションを構成できます。**JBP_CONFIG_DYNATRACEAGENT** 環境変数は、Dynatrace エージェントのダウンロード元となるビルドパックを指示します。この環境変数を設定するには、以下の手順に従ってください。
+モニター対象の Liberty アプリケーションは、以前にセットアップしたエージェント jar をホストするサーバーを検出するように構成する必要があります。**JBP_CONFIG_DYNATRACEAPPMONAGENT** 環境変数を使用してアプリケーションを構成できます。**JBP_CONFIG_DYNATRACEAPPMONAGENT** 環境変数は、Dynatrace エージェントのダウンロード元となるビルドパックを指示します。この環境変数を設定するには、以下の手順に従ってください。
 <ol>
-   <li> 値が *"repository_root: URL_of_server_hosting_index.yml"* になるように変数 **JBP_CONFIG_DYNATRACEAGENT** を設定します。例えば、アプリケーションのプッシュ後に次のコマンドを発行します。
+   <li> 値が *"repository_root: URL_of_server_hosting_index.yml"* になるように変数 **JBP_CONFIG_DYNATRACEAPPMONAGENT** を設定します。例えば、アプリケーションのプッシュ後に次のコマンドを発行します。
   
   <pre>   
-    $ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
+    $ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
   </pre>
   {: codeblock}
 

--- a/runtimes/liberty/nl/ja/environmentVariables.md
+++ b/runtimes/liberty/nl/ja/environmentVariables.md
@@ -43,7 +43,7 @@ Liberty for Java によってサポートされる環境変数。
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>[Dynatrace エージェント・ロケーション情報](dynatrace.html#configuring_liberty_app)を構成します</td>
 </tr>
 

--- a/runtimes/liberty/nl/ko/dynatrace.md
+++ b/runtimes/liberty/nl/ko/dynatrace.md
@@ -80,13 +80,13 @@ Dynatrace 에이전트는 웹 서버에 호스트되어야 하며, Liberty 빌�
 ### Liberty 앱 구성
 {: #configuring_liberty_app}
 
-이전에 설정한 에이전트 jar를 호스트하는 서버를 찾으려면 모니터할 Liberty 앱이 구성되어야 합니다. **JBP_CONFIG_DYNATRACEAGENT** 환경 변수를 사용하여 앱을 구성할 수 있습니다. **JBP_CONFIG_DYNATRACEAGENT** 환경 변수는 Dynatrace 에이전트를 다운로드할 소스 빌드팩을 알려줍니다. 이 환경 변수를 설정하려면 다음 단계를 완료하십시오. 
+이전에 설정한 에이전트 jar를 호스트하는 서버를 찾으려면 모니터할 Liberty 앱이 구성되어야 합니다. **JBP_CONFIG_DYNATRACEAPPMONAGENT** 환경 변수를 사용하여 앱을 구성할 수 있습니다. **JBP_CONFIG_DYNATRACEAPPMONAGENT** 환경 변수는 Dynatrace 에이전트를 다운로드할 소스 빌드팩을 알려줍니다. 이 환경 변수를 설정하려면 다음 단계를 완료하십시오. 
 <ol>
-   <li> **JBP_CONFIG_DYNATRACEAGENT** 변수에
+   <li> **JBP_CONFIG_DYNATRACEAPPMONAGENT** 변수에
 *"repository_root: URL_of_server_hosting_index.yml"* 값을 설정하십시오. 예를 들어 애플리케이션을 푸시한 후 다음 명령을 실행하십시오.
   
   <pre>   
-$ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
+$ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
   </pre>
   {: codeblock}
 

--- a/runtimes/liberty/nl/ko/environmentVariables.md
+++ b/runtimes/liberty/nl/ko/environmentVariables.md
@@ -43,7 +43,7 @@ Java용 Liberty에서 지원하는 환경 변수
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>[Dynatrace 에이전트 위치 정보](dynatrace.html#configuring_liberty_app)를 구성합니다.</td>
 </tr>
 

--- a/runtimes/liberty/nl/pt/BR/dynatrace.md
+++ b/runtimes/liberty/nl/pt/BR/dynatrace.md
@@ -92,13 +92,13 @@ arquivo jar do agente apropriado para execução no Bluemix é o
 ### Configurando o app Liberty
 {: #configuring_liberty_app}
 
-O app Liberty que você deseja monitorar deve ser configurado para localizar o servidor que hospeda o jar do agente configurado anteriormente. É possível configurar o app com a variável de ambiente **JBP_CONFIG_DYNATRACEAGENT**. A variável de ambiente **JBP_CONFIG_DYNATRACEAGENT** instrui o buildpack a partir de onde fazer download do agente Dynatrace. Para configurar a variável de ambiente, conclua estas etapas:
+O app Liberty que você deseja monitorar deve ser configurado para localizar o servidor que hospeda o jar do agente configurado anteriormente. É possível configurar o app com a variável de ambiente **JBP_CONFIG_DYNATRACEAPPMONAGENT**. A variável de ambiente **JBP_CONFIG_DYNATRACEAPPMONAGENT** instrui o buildpack a partir de onde fazer download do agente Dynatrace. Para configurar a variável de ambiente, conclua estas etapas:
 <ol>
-   <li> Configure a variável **JBP_CONFIG_DYNATRACEAGENT** para que tenha o valor
+   <li> Configure a variável **JBP_CONFIG_DYNATRACEAPPMONAGENT** para que tenha o valor
    *"repository_root: URL_of_server_hosting_index.yml"*. Por exemplo, depois de enviar por push seu aplicativo, emita o comando a seguir:
   
   <pre>   
-    $ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
+    $ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
   </pre>
   {: codeblock}
 

--- a/runtimes/liberty/nl/pt/BR/environmentVariables.md
+++ b/runtimes/liberty/nl/pt/BR/environmentVariables.md
@@ -43,7 +43,7 @@ Variáveis de ambiente suportadas pelo Liberty for Java.
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>Configure as [informações de local do agente Dynatrace](dynatrace.html#configuring_liberty_app)</td>
 </tr>
 

--- a/runtimes/liberty/nl/zh/CN/dynatrace.md
+++ b/runtimes/liberty/nl/zh/CN/dynatrace.md
@@ -78,12 +78,12 @@ Dynatrace 代理程序必须在 Web 服务器上进行托管，并且 Liberty bu
 ### 配置 Liberty 应用程序
 {: #configuring_liberty_app}
 
-必须将要监视的 Liberty 应用程序配置为可找到先前设置的托管代理程序 jar 的服务器。可以使用 **JBP_CONFIG_DYNATRACEAGENT** 环境变量来配置应用程序。**JBP_CONFIG_DYNATRACEAGENT** 环境变量会通知 buildpack 从什么位置下载 Dynatrace 代理程序。要设置该环境变量，请完成以下步骤：
+必须将要监视的 Liberty 应用程序配置为可找到先前设置的托管代理程序 jar 的服务器。可以使用 **JBP_CONFIG_DYNATRACEAPPMONAGENT** 环境变量来配置应用程序。**JBP_CONFIG_DYNATRACEAPPMONAGENT** 环境变量会通知 buildpack 从什么位置下载 Dynatrace 代理程序。要设置该环境变量，请完成以下步骤：
 <ol>
-   <li> 设置变量 **JBP_CONFIG_DYNATRACEAGENT**，使其具有值 *"repository_root: URL_of_server_hosting_index.yml"*。例如，推送应用程序后，发出以下命令：
+   <li> 设置变量 **JBP_CONFIG_DYNATRACEAPPMONAGENT**，使其具有值 *"repository_root: URL_of_server_hosting_index.yml"*。例如，推送应用程序后，发出以下命令：
   
   <pre>   
-$ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'  </pre>
+$ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'  </pre>
   {: codeblock}
 
   在此示例中，*my-dynatrace-agent-host.mybluemix.net* 是先前配置的服务器托管的 index.yml 文件的 URL。

--- a/runtimes/liberty/nl/zh/CN/environmentVariables.md
+++ b/runtimes/liberty/nl/zh/CN/environmentVariables.md
@@ -43,7 +43,7 @@ Liberty for Java 支持的环境变量。
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>配置 [Dynatrace 代理程序位置信息](dynatrace.html#configuring_liberty_app)</td>
 </tr>
 

--- a/runtimes/liberty/nl/zh/TW/dynatrace.md
+++ b/runtimes/liberty/nl/zh/TW/dynatrace.md
@@ -81,12 +81,12 @@ Dynatrace 代理程式必須在 Web 伺服器上進行管理，而 Liberty 建�
 ### 配置 Liberty 應用程式
 {: #configuring_liberty_app}
 
-必須配置您要監視的 Liberty 應用程式，才能找出管理您先前設定之代理程式 Jar 的伺服器。您可以使用 **JBP_CONFIG_DYNATRACEAGENT** 環境變數配置應用程式。**JBP_CONFIG_DYNATRACEAGENT** 環境變數告知建置套件從何處下載 Dynatrace 代理程式。若要設定此環境變數，請完成下列步驟：
+必須配置您要監視的 Liberty 應用程式，才能找出管理您先前設定之代理程式 Jar 的伺服器。您可以使用 **JBP_CONFIG_DYNATRACEAPPMONAGENT** 環境變數配置應用程式。**JBP_CONFIG_DYNATRACEAPPMONAGENT** 環境變數告知建置套件從何處下載 Dynatrace 代理程式。若要設定此環境變數，請完成下列步驟：
 <ol>
-   <li> 將 **JBP_CONFIG_DYNATRACEAGENT** 變數的值設為 *"repository_root：URL_of_server_hosting_index.yml"*。例如，在推送您的應用程式之後發出下列指令：
+   <li> 將 **JBP_CONFIG_DYNATRACEAPPMONAGENT** 變數的值設為 *"repository_root：URL_of_server_hosting_index.yml"*。例如，在推送您的應用程式之後發出下列指令：
   
   <pre>   
-    $ cf se myApp JBP_CONFIG_DYNATRACEAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
+    $ cf se myApp JBP_CONFIG_DYNATRACEAPPMONAGENT 'repository_root: https://my-dynatrace-agent-host.mybluemix.net'
   </pre>
   {: codeblock}
 

--- a/runtimes/liberty/nl/zh/TW/environmentVariables.md
+++ b/runtimes/liberty/nl/zh/TW/environmentVariables.md
@@ -43,7 +43,7 @@ Liberty for Java 支援的環境變數。
 </tr>
 
 <tr>
-<td>JBP_CONFIG_DYNATRACEAGENT</td>
+<td>JBP_CONFIG_DYNATRACEAPPMONAGENT</td>
 <td>配置 [Dynatrace 代理程式位置資訊](dynatrace.html#configuring_liberty_app)</td>
 </tr>
 


### PR DESCRIPTION
As a result of PR [#317](https://github.com/cloudfoundry/ibm-websphere-liberty-buildpack/pull/317) on the websphere-liberty-buildpack, some renaming of classes has occurred (~Nov/2016).  After consultation with @jgawor, this PR updates Bluemix docs related to the config guidance for self-hosting of the Dynatrace Agent Jars.  Specifically, the environment variable **JBP_CONFIG_DYNATRACEAGENT** is no longer valid and should be replaced with **JBP_CONFIG_DYNATRACEAPPMONAGENT** to accommodate the liberty buildpack renaming changes.  