### PR TITLE
Update openwhisk_actions.md to remove extra step in docker sdk

### DIFF
--- a/openwhisk/openwhisk_actions.md
+++ b/openwhisk/openwhisk_actions.md
@@ -788,10 +788,6 @@ For the instructions that follow, assume that the Docker user ID is `janesmith` 
   ```
   {: pre}
   ```
-  chmod +x buildAndPush.sh
-  ```
-  {: pre}
-  ```
   ./buildAndPush.sh janesmith/blackboxdemo
   ```
   {: pre}


### PR DESCRIPTION
This step is not longer need it since it got fixed int he CLI https://github.com/openwhisk/openwhisk/pull/1686

This change is not live, yet will merge once it's live