### PR TITLE
openwhisk: docs sync 0130

### DIFF
--- a/openwhisk/openwhisk_actions.md
+++ b/openwhisk/openwhisk_actions.md
@@ -411,7 +411,6 @@ First, `package.json`:
 ```
 {
   "name": "my-action",
-  "version": "1.0.0",
   "main": "index.js",
   "dependencies" : {
     "left-pad" : "1.1.3"
@@ -434,6 +433,7 @@ exports.main = myAction;
 {: codeblock}
 
 Note that the action is exposed through `exports.main`; the action handler itself can have any name, as long as it conforms to the usual signature of accepting an object and returning an object (or a `Promise` of an object).
+Per Node.js convention, you must either name this file `index.js` or specify the the file name you prefer as the `main` property in package.json.
 
 To create an OpenWhisk action from this package:
 

--- a/openwhisk/openwhisk_catalog.md
+++ b/openwhisk/openwhisk_catalog.md
@@ -139,7 +139,7 @@ If you're not using {{site.data.keyword.openwhisk_short}} in {{site.data.keyword
 You can use the `changes` feed to configure a service to fire a trigger on every change to your Cloudant database. The parameters are as follows:
 
 - `dbname`: Name of Cloudant database.
-- `maxTriggers`: Stop firing triggers when this limit is reached. Defaults to 1000. You can set it to maximum 10,000. If you try to set more than 10,000, the request is rejected.
+- `maxTriggers`: Stop firing triggers when this limit is reached. Defaults to infinite.
 
 1. Create a trigger with the `changes` feed in the package binding that you created previously. Be sure to replace `/myNamespace/myCloudant` with your package name.
 
@@ -304,7 +304,7 @@ For more details about using cron syntax, see: http://crontab.org. Following are
 
 - `trigger_payload`: The value of this parameter becomes the content of the trigger every time the trigger is fired.
 
-- `maxTriggers`: Stop firing triggers when this limit is reached. Defaults to 1000. You can set it to maximum 10,000. If you try to set more than 10,000, the request is rejected.
+- `maxTriggers`: Stop firing triggers when this limit is reached. Defaults to 1,000,000. You can set it to infinite (-1).
 
 The following is an example of creating a trigger that will be fired once every 2 minutes with `name` and `place` values in the trigger event.
 


### PR DESCRIPTION
- Clarify nodejs zip actions, use can use index.js
- Update trigger limits definition for cloudant and alarm