### PR TITLE
Update OpenWhisk Swift examples

### DIFF
--- a/openwhisk/nl/de/openwhisk_actions.md
+++ b/openwhisk/nl/de/openwhisk_actions.md
@@ -741,7 +741,7 @@ docker run --rm -it -v "$(pwd):/owexec" openwhisk/swift3action bash
 Hierdurch wurde eine Datei 'hello.zip' in demselben Verzeichnis wie 'hello.swift' erstellt.
 - Laden Sie die Datei mit dem Aktionsnamen 'helloSwifty' in OpenWhisk hoch:
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 - Führen Sie den folgenden Befehl aus, um zu prüfen, wie viel schneller die Aktion ist: 

--- a/openwhisk/nl/es/openwhisk_actions.md
+++ b/openwhisk/nl/es/openwhisk_actions.md
@@ -760,7 +760,7 @@ docker run --rm -it -v "$(pwd):/owexec" openwhisk/swift3action bash
 Se ha creado el archivo hello.zip en el mismo directorio que hello.swift.
 -Cárguelo en OpenWhisk con el nombre de acción helloSwifty:
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 - Para comprobar lo rápido que es, ejecute 

--- a/openwhisk/nl/fr/openwhisk_actions.md
+++ b/openwhisk/nl/fr/openwhisk_actions.md
@@ -734,7 +734,7 @@ docker run --rm -it -v "$(pwd):/owexec" openwhisk/swift3action bash
 Vous avez créé hello.zip dans le même répertoire qu'hello.swift.
 -Téléchargez-le dans OpenWhisk avec le nom d'action helloSwifty :
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 - Pour vous convaincre du gain en rapidité, exécutez 

--- a/openwhisk/nl/it/openwhisk_actions.md
+++ b/openwhisk/nl/it/openwhisk_actions.md
@@ -735,7 +735,7 @@ docker run --rm -it -v "$(pwd):/owexec" openwhisk/swift3action bash
 È stato creato hello.zip nella stessa directory di hello.swift. 
 -Caricalo in OpenWhisk con il nome azione helloSwifty:
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 - Per verificare la sua velocità, esegui 

--- a/openwhisk/nl/ja/openwhisk_actions.md
+++ b/openwhisk/nl/ja/openwhisk_actions.md
@@ -738,7 +738,7 @@ docker run --rm -it -v "$(pwd):/owexec" openwhisk/swift3action bash
 これで、hello.swift と同じディレクトリー内に hello.zip が作成されました。
 - これをアクション名 helloSwifty として OpenWhisk にアップロードします。
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 - どのくらい高速になったかを確認するには、以下を実行します

--- a/openwhisk/nl/ko/openwhisk_actions.md
+++ b/openwhisk/nl/ko/openwhisk_actions.md
@@ -748,7 +748,7 @@ docker run --rm -it -v "$(pwd):/owexec" openwhisk/swift3action bash
 이는 hello.swift와 동일한 디렉토리에 hello.zip을 작성했습니다.
 -조치 이름 helloSwifty로 OpenWhisk에 업로드하십시오.
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 - 얼마나 빠른지 확인하려면 다음을 실행하십시오.

--- a/openwhisk/nl/pt/BR/openwhisk_actions.md
+++ b/openwhisk/nl/pt/BR/openwhisk_actions.md
@@ -745,7 +745,7 @@ docker run --rm -it -v "$(pwd):/owexec" openwhisk/swift3action bash
 Isso criou hello.zip no mesmo diretório que hello.swift. 
 -Faça upload dele para o OpenWhisk com o nome de ação helloSwifty:
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 - Para verificar o quanto ele é mais rápido, execute 

--- a/openwhisk/nl/zh/CN/openwhisk_actions.md
+++ b/openwhisk/nl/zh/CN/openwhisk_actions.md
@@ -740,7 +740,7 @@ docker run --rm -it -v "$(pwd):/owexec" openwhisk/swift3action bash
 这已在 hello.swift 所在的目录中创建 hello.zip。
 -使用名为 helloSwifty 的操作将其上传到 OpenWhisk：
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 - 要检查其运行速度提高了多少，请运行

--- a/openwhisk/nl/zh/TW/openwhisk_actions.md
+++ b/openwhisk/nl/zh/TW/openwhisk_actions.md
@@ -726,7 +726,7 @@ docker run --rm -it -v "$(pwd):/owexec" openwhisk/swift3action bash
 此作業已在與 hello.swift 相同的目錄中建立 hello.zip。
 - 使用動作名稱 helloSwifty，將它上傳至 OpenWhisk：
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 - 若要檢查速度快多少，請執行 

--- a/openwhisk/openwhisk_actions.md
+++ b/openwhisk/openwhisk_actions.md
@@ -759,7 +759,7 @@ To avoid the cold-start delay, you can compile your Swift file into a binary and
 
 - Upload it to OpenWhisk with the action name helloSwifty:
   ```
-  wsk action update helloSwiftly hello.zip --kind swift:3
+  wsk action update helloSwiftly hello.zip --kind swift:3.1.1
   ```
   {: pre}
 


### PR DESCRIPTION
This PR fixes #1463,  update OpenWhisk documentation to use kind Swift 3.1.1 